### PR TITLE
[Fix #23]: Hero section image not visible on small screen 

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -24,7 +24,7 @@ function Home() {
       <Navigation/>
 
     <div className="relative overflow-hidden bg-black">
-      <div className="flex pt-16 pb-24 sm:pt-24 sm:pb-0 lg:pt-40 lg:pb-16">
+      <div className="flex flex-col sm:flex-row pt-16 pb-24 sm:pt-24 sm:pb-0 lg:pt-40 lg:pb-16 ">
         <div className="relative mx-auto max-w-7xl px-4 sm:static sm:px-6 py-8 sm:py-0 lg:px-8">
           <div className="sm:max-w-lg">
             <h1 className="font text-4xl font-bold tracking-tight text-yellow sm:text-6xl">
@@ -46,7 +46,7 @@ function Home() {
             </div>
           </div>
         </div>                                                                                         
-       <img className='hidden w-3x1 h-3x1 sm:block' src='https://drive.google.com/uc?export=view&id=1vBY6fqRWPov53eKDNqTOpEkYjPgmRPQP'/>         
+       <img className='w-3x1 h-3x1 order-first sm:order-last' src='https://drive.google.com/uc?export=view&id=1vBY6fqRWPov53eKDNqTOpEkYjPgmRPQP'/>         
       </div>
     </div>
 


### PR DESCRIPTION
**Description**

This PR fixes #23 
Changed the flex direction to column in small screen and removed the class "hidden" from img tag of hero image.

#### Screenshot
- Before

![edunity flex col home before](https://github.com/roshangeorge97/Edunity/assets/84488726/d2e1fabc-22da-4540-88b4-150bcf0951cd)

- After
![edunity flex col home](https://github.com/roshangeorge97/Edunity/assets/84488726/387a594d-23d8-44a1-a329-8c77fd18a580)



<!--
Thank you for contributing to Edunity! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 


By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
